### PR TITLE
hotfix: re-introducing base_url into path for req

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -159,7 +159,7 @@ class RemoteConnection(Connection):
         headers['X-REMOTE-IP'] = web.ctx.get('ip') or ''
 
         try:
-            response = requests.request(method, path, data=data, headers=headers)
+            response = requests.request(method, self.base_url + path, data=data, headers=headers)
             if not response.ok:
                 response.raise_for_status()
             stats.end()


### PR DESCRIPTION
Hotfix for https://github.com/internetarchive/infogami/pull/160/files#diff-7f84f23b944c54d23421925bcdbe417ae9d876a5a6395c4b5104abf7f593b364

Logins and other infogami requests broken due to missing base_url from path.

To be verified: whether the param should be `url` from https://github.com/dhruvmanila/infogami/compare/master...mekarpeles:patch-2#diff-7f84f23b944c54d23421925bcdbe417ae9d876a5a6395c4b5104abf7f593b364R125 or `self.base_url + path`